### PR TITLE
Fix env copy instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ bot.py (main entry point)
 3. **Set environment variables**:
 
    ```bash
-   cp env.example .env
+   cp .env.example .env
    # Edit .env with your API keys
    ```
 
@@ -75,7 +75,7 @@ bot.py (main entry point)
    ```bash
    git clone <repository-url>
    cd youtube-content-summarizer
-   cp env.example .env
+   cp .env.example .env
    # Edit .env with your API keys
    ```
 


### PR DESCRIPTION
## Summary
- replace `cp env.example .env` with `cp .env.example .env` in README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_b_686b67de63a0832fa62bd5d7eaae748f