### PR TITLE
Add auto YouTube link summaries in group chats

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A fast, efficient Telegram bot that provides AI-powered summaries of YouTube vid
 - 🎥 **Video Summarization**: Get comprehensive summaries of YouTube videos with metadata
 - 🤖 **AI-Powered**: Uses Google Gemma 3 27B for high-quality summaries
 - 💬 **Interactive Q&A**: Ask follow-up questions about video content with context awareness
+- 🔗 **Auto Link Summaries**: Automatically summarizes YouTube links in group chats
 - ⚡ **Fast Processing**: Async architecture with concurrent request handling
 - 📊 **Rich Metadata**: Extracts video title, duration, uploader, view count, and more
 - 📈 **Smart Caching**: Video context caching with comprehensive metadata storage

--- a/bot.py
+++ b/bot.py
@@ -21,6 +21,7 @@ from handlers import (
     stats_command,
     summarize_command,
     handle_reply,
+    auto_summary_handler,
     handle_unknown_command,
     error_handler,
 )
@@ -57,6 +58,11 @@ class YouTubeSummarizerBot:
             MessageHandler(
                 filters.TEXT & filters.REPLY & ~filters.COMMAND, handle_reply
             )
+        )
+
+        # Auto-summarize YouTube links posted in group chats
+        self.application.add_handler(
+            MessageHandler(filters.TEXT & ~filters.COMMAND, auto_summary_handler)
         )
 
         # Handle unknown commands

--- a/handlers.py
+++ b/handlers.py
@@ -4,10 +4,11 @@ Telegram bot command and message handlers.
 
 import asyncio
 import logging
+import re
 from typing import Optional
 from telegram import Update, Message
 from telegram.ext import ContextTypes
-from telegram.constants import ParseMode, ChatAction
+from telegram.constants import ParseMode, ChatAction, ChatType
 
 from utils import (
     extract_video_id,
@@ -469,6 +470,62 @@ async def handle_reply(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             parse_mode=ParseMode.MARKDOWN_V2,
         )
         REQUEST_COUNT.labels(command="reply", status="unexpected_error").inc()
+
+
+async def auto_summary_handler(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    """Automatically summarize YouTube links posted in group chats."""
+    if update.effective_chat.type not in {ChatType.GROUP, ChatType.SUPERGROUP}:
+        return
+
+    message_text = update.message.text or ""
+
+    # Find potential URLs in the message
+    urls = re.findall(r"https://\S+", message_text)
+    video_id: Optional[str] = None
+    for url in urls:
+        cleaned = url.rstrip(".,")
+        vid = extract_video_id(cleaned)
+        if vid:
+            video_id = vid
+            break
+
+    if not video_id:
+        return
+
+    REQUEST_COUNT.labels(command="autosummary", status="received").inc()
+
+    try:
+        await context.bot.send_chat_action(
+            chat_id=update.effective_chat.id, action=ChatAction.TYPING
+        )
+
+        video_context = await get_video_context(video_id)
+        summary = await gemini_client.generate_brief_summary(
+            video_context["transcript"]["text"]
+        )
+
+        escaped_summary = escape_markdown_v2(summary)
+        reply_msg = await update.message.reply_text(
+            f"🎬 **Quick Summary:**\n\n{escaped_summary}",
+            parse_mode=ParseMode.MARKDOWN_V2,
+        )
+
+        # Store context for follow-up questions
+        video_context["summary"] = summary
+        video_context["summary_timestamp"] = asyncio.get_event_loop().time()
+        transcript_cache.put_video_context(
+            chat_id=update.effective_chat.id,
+            message_id=reply_msg.message_id,
+            video_context=video_context,
+        )
+
+        REQUEST_COUNT.labels(command="autosummary", status="success").inc()
+
+    except Exception as e:
+        logger.error(f"Auto summary failed: {e}")
+        REQUEST_COUNT.labels(command="autosummary", status="error").inc()
 
 
 async def handle_unknown_command(


### PR DESCRIPTION
## Summary
- auto summarize YouTube links posted in group chats
- implement concise summary generator in `gemini.py`
- register new handler in bot initialization
- document auto link summary feature in README

## Testing
- `python -m py_compile bot.py handlers.py utils.py gemini.py youtube.py cache.py`
- `pip install -q -r requirements.txt`
- `python -c "from utils import extract_video_id; print(extract_video_id('https://youtu.be/dQw4w9WgXcQ'))"`
- `python -c "from utils import clean_transcript_text; print(clean_transcript_text('[Music] Hello world [Applause]'))"`


------
https://chatgpt.com/codex/tasks/task_b_686b69846370832f977f51759c3f23b5